### PR TITLE
Handle disconnected state

### DIFF
--- a/huber/driver.py
+++ b/huber/driver.py
@@ -69,7 +69,7 @@ class Bath(object):
         output = {}
         for default in self.defaults:
             util.set_nested(output, default, await self._get(default))
-        if 'status' in output:
+        if output.get('status'):
             for fault in ['warning', 'error']:
                 if output['status'][fault]:
                     output[fault] = await self._get(fault)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='huber',
-    version='0.3.0',
+    version='0.3.1',
     description='Python driver for Huber recirculating baths.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
If the huber is unreachable, the output['status'] comes back as `None` which leads to errors like this:
```Traceback (most recent call last):
  File "/src/controllers/controllers/pilot_lab/controller.py", line 207, in _sensor_loop
    await self._sense()
  File "/src/controllers/controllers/pilot_lab/controller.py", line 219, in _sense
    self._sense_serial('fv4')
  File "/src/controllers/controllers/pilot_lab/controller.py", line 193, in _sense_bath
    self.state['bath'] = await self.bath.get()
  File "/usr/local/lib/python3.6/site-packages/huber/driver.py", line 74, in get
    if output['status'][fault]:
TypeError: 'NoneType' object is not subscriptable
```

This change catches that case and prevents these from spamming the logs