### PR TITLE
:pencil: Increase default timeout to 500ms, and make it adjustable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as in_file:
 
 setup(
     name='huber',
-    version='0.6.0',
+    version='0.6.1',
     description='Python driver for Huber recirculating baths.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Replies from Huber, according to manual, takes less than 300ms.
I increased the default timeout to be 500ms - but left the option for reducing or increasing it to account for network latency.